### PR TITLE
Allow number of VMs online to be limited

### DIFF
--- a/src/main/resources/hudson/plugins/libvirt/Hypervisor/config.jelly
+++ b/src/main/resources/hudson/plugins/libvirt/Hypervisor/config.jelly
@@ -19,6 +19,9 @@
         <f:entry title="${%Hypervisor System Url}" field="hypervisorSystemUrl">
             <f:textbox default="system"/>
         </f:entry>
+        <f:entry title="${%Max number of slaves online}" help="/plugin/libvirt-slave/help-libvirt-maxOnlineSlaves.html">
+            <f:textbox clazz="required number" field="maxOnlineSlaves" />
+        </f:entry>
     </f:advanced>
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="hypervisorType,hypervisorHost,username,hypervisorSshPort,hypervisorSystemUrl"/>
 </j:jelly>

--- a/src/main/webapp/help-libvirt-maxOnlineSlaves.html
+++ b/src/main/webapp/help-libvirt-maxOnlineSlaves.html
@@ -1,0 +1,1 @@
+<div>Maximum number of virtual machines that this libvirt cloud should use at one time. A value of 0 indicates no maximum value.</div>


### PR DESCRIPTION
Adds an option to the Hypervisor configuration that allows the number of VMs online at once to be limited.

Code adapted from the Jenkins vSphere cloud plugin at commit "f3548bffde" (https://github.com/jenkinsci/vsphere-cloud-plugin/tree/f3548bffde1d268270464236f59fce68474de2f5).
