### PR TITLE
Sort the VM list provided to the Node config UI

### DIFF
--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineSlave.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineSlave.java
@@ -39,6 +39,7 @@ import hudson.util.ListBoxModel;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -133,6 +134,7 @@ public class VirtualMachineSlave extends Slave {
             Hypervisor hypervisor = getHypervisorByDescription(hypervisorDescription);
             if (hypervisor != null)
             	virtualMachinesList.addAll(hypervisor.getVirtualMachines());
+            Collections.sort(virtualMachinesList);
             return virtualMachinesList;
         }
 


### PR DESCRIPTION
The current arbitrary ordering of VMs in the Node configuration's Virtual Machine drop-down makes it very hard to find the desired VM when the list is large.

This fix uses the standard Collections sort method to sort the VMs according to the natural ordering of their names.
