### PR TITLE
Starting slave via Java Web Start is not possible

### DIFF
--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineLauncher.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineLauncher.java
@@ -93,7 +93,7 @@ public class VirtualMachineLauncher extends ComputerLauncher {
 
     @Override
     public boolean isLaunchSupported() {
-        return delegate.isLaunchSupported();
+        return true;
     }
 
     public Hypervisor findOurHypervisorInstance() throws RuntimeException {


### PR DESCRIPTION
This is due to fact that JNLPLauncher.isLaunchSupported() returns false. To fix this,
VirtualMachineLauncher.isLaunchSupported() should always return true,
and not ask delegate.
