### PR TITLE
fix: Slave should be shut down only if idle 

### DIFF
--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineSlave.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineSlave.java
@@ -87,7 +87,12 @@ public class VirtualMachineSlave extends Slave {
         return ((VirtualMachineLauncher) getLauncher()).getDelegate();
     }
 
-    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+    @Override
+	public Computer createComputer() {
+		return new VirtualMachineSlaveComputer(this);
+	}
+
+	public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     @Extension
     public static class VirtualMachineComputerListener extends ComputerListener {

--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineSlaveComputer.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineSlaveComputer.java
@@ -20,18 +20,77 @@
 
 package hudson.plugins.libvirt;
 
-import hudson.slaves.SlaveComputer;
+import hudson.model.TaskListener;
 import hudson.model.Slave;
-import org.libvirt.Connect;
+import hudson.slaves.OfflineCause;
+import hudson.slaves.SlaveComputer;
+import hudson.util.StreamTaskListener;
+import hudson.util.io.ReopenableRotatingFileOutputStream;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.libvirt.Domain;
+import org.libvirt.DomainInfo.DomainState;
 
 public class VirtualMachineSlaveComputer extends SlaveComputer {
 
-    /**
-     * Cached connection to the virtaul datacenter. Lazily fetched.
-     */
-    private volatile Connect hypervisorConnection;
-
+	private static final Logger logger = Logger.getLogger(VirtualMachineSlaveComputer.class.getName());
+			
+	private final TaskListener taskListener;
+	
     public VirtualMachineSlaveComputer(Slave slave) {
-        super(slave);
+        super(slave);    
+        this.taskListener = new StreamTaskListener(new ReopenableRotatingFileOutputStream(getLogFile(),10));
     }
+
+	@Override
+	public Future<?> disconnect(OfflineCause cause) {
+		VirtualMachineSlave slave = (VirtualMachineSlave) getNode();
+		String virtualMachineName = slave.getVirtualMachineName();
+		VirtualMachineLauncher vmL = (VirtualMachineLauncher) getLauncher();
+		Hypervisor hypervisor = vmL.findOurHypervisorInstance();
+		logger.log(Level.INFO, "Virtual machine \"" + virtualMachineName + "\" (slave \"" + getDisplayName() + "\") is to be shut down. reason: "+cause+" ("+cause.getClass().getName()+")");
+		taskListener.getLogger().println("Virtual machine \"" + virtualMachineName + "\" (slave \"" + getDisplayName() + "\") is to be shut down.");
+		try {			
+            Map<String, Domain> computers = hypervisor.getDomains();
+            Domain domain = computers.get(virtualMachineName);
+            if (domain != null) {
+            	if (domain.getInfo().state.equals(DomainState.VIR_DOMAIN_RUNNING) || domain.getInfo().state.equals(DomainState.VIR_DOMAIN_BLOCKED)) {
+            		String snapshotName = slave.getSnapshotName();
+                    if (snapshotName != null && snapshotName.length() > 0) {
+                    	taskListener.getLogger().println("Reverting to " + snapshotName + " and shutting down.");
+                    	domain.revertToSnapshot(domain.snapshotLookupByName(snapshotName));
+                    } else {
+                    	taskListener.getLogger().println("Shutting down.");
+                    	domain.shutdown();
+                    }
+                } else {
+                    taskListener.getLogger().println("Already suspended, no shutdown required.");
+                }
+                Hypervisor vmC = vmL.findOurHypervisorInstance();
+                vmC.markVMOffline(getDisplayName(), vmL.getVirtualMachineName());
+            } else {
+            	// log to slave 
+            	taskListener.getLogger().println("\"" + virtualMachineName + "\" not found on Hypervisor, can not shut down!");
+            	
+            	// log to jenkins
+            	LogRecord rec = new LogRecord(Level.WARNING, "Can not shut down {0} on Hypervisor {1}, domain not found!");
+                rec.setParameters(new Object[]{virtualMachineName, hypervisor.getHypervisorURI()});
+                logger.log(rec);
+            }
+        } catch (Throwable t) {
+        	taskListener.fatalError(t.getMessage(), t);
+        	
+            LogRecord rec = new LogRecord(Level.SEVERE, "Error while shutting down {0} on Hypervisor {1}.");
+            rec.setParameters(new Object[]{slave.getVirtualMachineName(), hypervisor.getHypervisorURI()});
+            rec.setThrown(t);
+            logger.log(rec);
+        }
+		return super.disconnect(cause);
+	}
+    	
 }


### PR DESCRIPTION
The latest version of the plugin shutdowns a slave, no matter if a job is running or not, if Jenkins master looses the network connection with the slave. This should not happen because Jenkins slaves are capable of reestablishing it. 

The root of the problem is that the slave shutdown happens in VirtulMachineLauncher.afterDisconnect(), triggered everytime when the connection between master and slave goes down. The provided patch fixes that.
