### PR TITLE
Add bhyve support

### DIFF
--- a/src/main/java/hudson/plugins/libvirt/Hypervisor.java
+++ b/src/main/java/hudson/plugins/libvirt/Hypervisor.java
@@ -502,6 +502,7 @@ public class Hypervisor extends Cloud {
             types.add("QEMU");
             types.add("XEN");
             types.add("LXC");
+            types.add("BHYVE");
             return types;
         }
     }


### PR DESCRIPTION
Add 'bhyve' hypervisor type support to allow using libvirt bhyve (BSD
hypervisor) driver appeared in libvirt 1.2.2.
