### PR TITLE
fix(NPE): finalized Run may have null Executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
+.idea/
 *.iml

--- a/src/main/java/hudson/plugins/libvirt/LibvirtRunListener.java
+++ b/src/main/java/hudson/plugins/libvirt/LibvirtRunListener.java
@@ -30,7 +30,11 @@ public final class LibvirtRunListener extends RunListener<Run> {
     @Override
     public void onFinalized(Run r) {
         super.onFinalized(r);
-        Computer computer = r.getExecutor().getOwner();
+        Executor executor = r.getExecutor();
+        if (executor == null) {
+            return;
+        }
+        Computer computer = executor.getOwner();
         Node node = computer.getNode();
 
 


### PR DESCRIPTION
Fixes this error which appears in jenkins.log periodically:

	Sep 22, 2015 6:00:02 PM hudson.model.listeners.RunListener report
	WARNING: RunListener failed
	java.lang.NullPointerException
	        at hudson.plugins.libvirt.LibvirtRunListener.onFinalized(LibvirtRunListener.java:33)
	        at hudson.model.listeners.RunListener.fireFinalized(RunListener.java:230)
	        at hudson.model.Run.onEndBuilding(Run.java:1890)
	        at hudson.maven.MavenBuild.access$600(MavenBuild.java:104)
	        at hudson.maven.MavenBuild$ProxyImpl2.end(MavenBuild.java:587)
	        at sun.reflect.GeneratedMethodAccessor817.invoke(Unknown Source)
	        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	        at java.lang.reflect.Method.invoke(Method.java:606)
	        at hudson.model.Executor$2.call(Executor.java:895)
	        at hudson.util.InterceptingProxy$1.invoke(InterceptingProxy.java:23)
	        at com.sun.proxy.$Proxy79.end(Unknown Source)
	        at sun.reflect.GeneratedMethodAccessor1089.invoke(Unknown Source)
	        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	        at java.lang.reflect.Method.invoke(Method.java:606)
	        at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:608)
	        at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:583)
	        at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:542)
	        at hudson.remoting.UserRequest.perform(UserRequest.java:121)
	        at hudson.remoting.UserRequest.perform(UserRequest.java:49)
	        at hudson.remoting.Request$2.run(Request.java:326)
	        at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	        at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:18)
	        at hudson.remoting.CallableDecoratorList$1.call(CallableDecoratorList.java:21)
	        at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	        at java.lang.Thread.run(Thread.java:745)
