### PR TITLE
remove space in markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Jenkins Logo] (http://jenkins-ci.org/sites/default/files/jenkins_logo.png)
+![Jenkins Logo](http://jenkins-ci.org/sites/default/files/jenkins_logo.png)
 
 About libvirt-slave-plugin
 =====


### PR DESCRIPTION
remove the space to display the logo correctly