### PR TITLE
Pipeline projects do not trigger libvirt VM snapshot reverts [JENKINS-50552]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 .idea/
 *.iml
+.classpath
+.project
+.settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+### 1.9.2
+
+Unrelease
+
+-   Fix [JENKINS-50552](https://issues.jenkins.io/browse/JENKINS-50552):
+    Pipeline projects do not trigger libvirt VM snapshot reverts.
+
 ### 1.9.1
 
 Release date: _Mar 4, 2021_
 
--   Fix [JENKINS-64698](https://issues.jenkins.io/browse/JENKINS-64698A):
+-   Fix [JENKINS-64698](https://issues.jenkins.io/browse/JENKINS-64698):
     Cannot create a libvirt agent
     (Thanks to Benoit Guerin for the contribution)
 -   Fix SECURITY-1764:

--- a/src/main/java/hudson/plugins/libvirt/ComputerUtils.java
+++ b/src/main/java/hudson/plugins/libvirt/ComputerUtils.java
@@ -1,0 +1,187 @@
+package hudson.plugins.libvirt;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+
+import hudson.model.Computer;
+import hudson.model.TaskListener;
+import hudson.plugins.libvirt.lib.IDomain;
+import hudson.plugins.libvirt.lib.IDomainSnapshot;
+import hudson.plugins.libvirt.lib.VirtException;
+import hudson.slaves.OfflineCause;
+
+public final class ComputerUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(ComputerUtils.class.getName());
+
+    private static final int RETRY_MAX = 5;
+
+    private static final int RETRY_WAIT_MS = 500;
+
+    private ComputerUtils() {
+    }
+
+    public static void disconnect(final String name, final Computer computer) {
+        disconnect(name, computer, null);
+    }
+
+    public static void disconnect(final String name, final Computer computer,
+            @CheckForNull final TaskListener listener) {
+        try {
+            computer.getChannel().syncLocalIO();
+            try {
+                computer.getChannel().close();
+                computer.disconnect(new OfflineCause.ByCLI("Stopping " + name + "."));
+                try {
+                    computer.waitUntilOffline();
+                } catch (final InterruptedException e) {
+                    error(listener, "Interrupted while waiting for computer to be offline: " + e);
+                }
+            } catch (final IOException e) {
+                error(listener, "Error closing channel: " + e);
+            }
+        } catch (final InterruptedException e) {
+            error(listener, "Interrupted while syncing IO: " + e);
+        } catch (final NullPointerException e) {
+            error(listener, "Could not determine channel.");
+        }
+    }
+
+    public static void start(final VirtualMachine virtualMachine) {
+        start(virtualMachine, null);
+    }
+
+    public static void start(final VirtualMachine virtualMachine, @CheckForNull final TaskListener listener) {
+        final IDomain domain = getDomain(virtualMachine, listener);
+        if (domain != null) {
+            try {
+                if (domain.isRunningOrBlocked()) {
+                    log(listener, "Machine " + virtualMachine.getName()
+                            + " is already running, no startup required.");
+                    return;
+                }
+            } catch (final VirtException e) {
+                error(listener, "Error checking if " + virtualMachine.getName()
+                        + " is already running, will consider it as stopped.");
+            }
+
+            for (int i = 0; i < RETRY_MAX; i++) {
+                try {
+                    log(listener, "Starting " + virtualMachine.getName() + "...");
+                    domain.create();
+                } catch (final VirtException e) {
+                    try {
+                        Thread.sleep(RETRY_WAIT_MS);
+                    } catch (final Exception e2) {
+                    }
+                    continue;
+                }
+                break;
+            }
+        }
+    }
+
+    public static void stop(final VirtualMachine virtualMachine, final String shutdownMethod) {
+        stop(virtualMachine, shutdownMethod, null);
+    }
+
+    public static void stop(final VirtualMachine virtualMachine, final String shutdownMethod,
+            @CheckForNull final TaskListener listener) {
+        final IDomain domain = getDomain(virtualMachine, listener);
+        if (domain != null) {
+            try {
+                if (domain.isNotBlockedAndNotRunning()) {
+                    log(listener,
+                            "Machine " + virtualMachine.getName() + " is not running, no shutdown required.");
+                    return;
+                }
+            } catch (final VirtException e) {
+                error(listener, "Error checking if " + virtualMachine.getName()
+                        + " is stopped, will consider it as running.");
+            }
+
+            for (int i = 0; i < RETRY_MAX; i++) {
+                try {
+                    log(listener, "Stopping " + virtualMachine.getName() + " (using method " + shutdownMethod
+                            + ")...");
+                    if ("suspend".equals(shutdownMethod)) {
+                        domain.suspend();
+                    } else if ("destroy".equals(shutdownMethod)) {
+                        domain.destroy();
+                    } else {
+                        domain.shutdown();
+                    }
+                } catch (final VirtException e) {
+                    try {
+                        Thread.sleep(RETRY_WAIT_MS);
+                    } catch (final Exception e2) {
+                    }
+                    continue;
+                }
+                break;
+            }
+        }
+    }
+
+    public static void revertToSnapshot(final VirtualMachine virtualMachine, final String snapshotName) {
+        revertToSnapshot(virtualMachine, snapshotName, null);
+    }
+
+    public static void revertToSnapshot(final VirtualMachine virtualMachine, final String snapshotName,
+            @CheckForNull final TaskListener listener) {
+        if (snapshotName != null && snapshotName.length() > 0) {
+            final IDomain domain = getDomain(virtualMachine, listener);
+            if (domain != null) {
+                try {
+                    final IDomainSnapshot snapshot = domain.snapshotLookupByName(snapshotName);
+                    try {
+                        log(listener, "Reverting " + virtualMachine.getName() + " to snapshot " + snapshotName
+                                + ".");
+                        domain.revertToSnapshot(snapshot);
+                    } catch (final VirtException e) {
+                        error(listener, "Error reverting to snapshot named " + snapshotName + " for VM "
+                                + virtualMachine.getName() + ": " + e);
+                    }
+                } catch (final VirtException e) {
+                    error(listener, "No snapshot named " + snapshotName + " for VM "
+                            + virtualMachine.getName() + ": " + e);
+                }
+
+            }
+        }
+    }
+
+    private static @CheckForNull IDomain getDomain(final VirtualMachine virtualMachine,
+            @CheckForNull final TaskListener listener) {
+        IDomain domain = null;
+        try {
+            final Map<String, IDomain> domains = virtualMachine.getHypervisor().getDomains();
+            domain = domains.get(virtualMachine.getName());
+            if (domain == null) {
+                error(listener, "No VM named " + virtualMachine.getName());
+            }
+        } catch (final VirtException e) {
+            error(listener, "Can't get VM domains: " + e);
+        }
+        return domain;
+    }
+
+    private static void log(@CheckForNull final TaskListener listener, final String message) {
+        if (listener != null) {
+            listener.getLogger().println(message);
+        }
+        LOGGER.log(Level.INFO, message);
+    }
+
+    private static void error(@CheckForNull final TaskListener listener, final String message) {
+        if (listener != null) {
+            listener.fatalError(message);
+        }
+        LOGGER.log(Level.WARNING, message);
+    }
+
+}

--- a/src/main/java/hudson/plugins/libvirt/LibvirtRunListener.java
+++ b/src/main/java/hudson/plugins/libvirt/LibvirtRunListener.java
@@ -2,28 +2,21 @@ package hudson.plugins.libvirt;
 
 import hudson.model.Node;
 import hudson.model.Run;
-import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Executor;
-import java.util.Map;
-
-import hudson.plugins.libvirt.lib.IDomain;
-import hudson.plugins.libvirt.lib.VirtException;
-import java.io.IOException;
 
 @Extension
 public final class LibvirtRunListener extends RunListener<Run<?, ?>> {
-    private static final int RETRY_MAX = 5;
-    private static final int RETRY_WAIT_MS = 500;
+
+    private static final Logger LOGGER = Logger.getLogger(LibvirtRunListener.class.getName());
 
     public LibvirtRunListener() {
-    }
-
-    @Override
-    public void onStarted(final Run<?, ?> r, final TaskListener listener) {
-        super.onStarted(r, listener);
     }
 
     @Override
@@ -42,32 +35,15 @@ public final class LibvirtRunListener extends RunListener<Run<?, ?>> {
 
             if (slave.getRebootAfterRun()) {
 
-                try {
-                    System.err.println("NukeSlaveListener about to disconnect. The next error about an agent disconnecting is normal");
-                    computer.getChannel().syncLocalIO();
-                    computer.getChannel().close();
-                    computer.disconnect(null);
-                    computer.waitUntilOffline();
-                } catch (IOException | InterruptedException e) {
-                }
+                LOGGER.log(Level.INFO, "Virtual machine "  + slave.getVirtualMachineName() + " is to be shut down.");
+                ComputerUtils.disconnect(slave.getVirtualMachineName(), computer);
 
                 VirtualMachineLauncher launcher = (VirtualMachineLauncher) slave.getLauncher();
                 VirtualMachine virtualMachine = launcher.getVirtualMachine();
 
-                for (int i = 0; i < RETRY_MAX; i++) {
-                    try {
-                        Map<String, IDomain> computers = virtualMachine.getHypervisor().getDomains();
-                        IDomain domain = computers.get(virtualMachine.getName());
-                        domain.create();
-                    } catch (VirtException e) {
-                        try {
-                            Thread.sleep(RETRY_WAIT_MS);
-                        } catch (Exception e2) {
-                        }
-                        continue;
-                    }
-                    break;
-                }
+                ComputerUtils.stop(virtualMachine, slave.getShutdownMethod());
+                ComputerUtils.revertToSnapshot(virtualMachine, slave.getSnapshotName());
+                ComputerUtils.start(virtualMachine);
             }
         }
     }

--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineLauncher.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineLauncher.java
@@ -24,7 +24,6 @@ package hudson.plugins.libvirt;
 import hudson.model.TaskListener;
 
 import hudson.model.Descriptor;
-import hudson.plugins.libvirt.lib.IDomain;
 import hudson.plugins.libvirt.lib.VirtException;
 import hudson.slaves.Cloud;
 import hudson.slaves.ComputerLauncher;
@@ -33,7 +32,6 @@ import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -132,46 +130,33 @@ public class VirtualMachineLauncher extends ComputerLauncher {
                 }
             }
 
-            Map<String, IDomain> computers = virtualMachine.getHypervisor().getDomains();
-            IDomain domain = computers.get(virtualMachine.getName());
-            if (domain != null) {
-                if (domain.isNotBlockedAndNotRunning()) {
-                    taskListener.getLogger().println("Starting, waiting for " + waitTimeMs + "ms to let it fully boot up...");
-                    domain.create();
-                    Thread.sleep(waitTimeMs);
+            ComputerUtils.start(virtualMachine, taskListener);
+            taskListener.getLogger().println("Waiting for " + waitTimeMs + "ms to let it fully boot up...");
+            Thread.sleep(waitTimeMs);
 
-                    int attempts = 0;
-                    while (true) {
-                        attempts++;
-
-                        taskListener.getLogger().println("Connecting agent client.");
-
-                        // This call doesn't seem to actually throw anything, but we'll catch IOException just in case
-                        try {
-                            delegate.launch(slaveComputer, taskListener);
-                        } catch (IOException e) {
-                            taskListener.getLogger().println("unexpectedly caught exception when delegating launch of agent: " + e.getMessage());
-                        }
-
-                        if (slaveComputer.isOnline()) {
-                            break;
-                        } else if (attempts >= timesToRetryOnFailure) {
-                            taskListener.getLogger().println("Maximum retries reached. Failed to start agent client.");
-                            break;
-                        }
-
-                        taskListener.getLogger().println("Not up yet, waiting for " + waitTimeMs + "ms more ("
-                                                         + attempts + "/" + timesToRetryOnFailure + " retries)...");
-                        Thread.sleep(waitTimeMs);
-                    }
-                } else {
-                    taskListener.getLogger().println("Already running, no startup required.");
+            int attempts = 0;
+            while (true) {
+                attempts++;
 
                 taskListener.getLogger().println("Connecting agent client.");
-                delegate.launch(slaveComputer, taskListener);
+
+                // This call doesn't seem to actually throw anything, but we'll catch IOException just in case
+                try {
+                    delegate.launch(slaveComputer, taskListener);
+                } catch (IOException e) {
+                    taskListener.getLogger().println("unexpectedly caught exception when delegating launch of agent: " + e.getMessage());
                 }
-            } else {
-                throw new IOException("VM \"" + virtualMachine.getName() + "\" (agent title \"" + slaveComputer.getDisplayName() + "\") not found!");
+
+                if (slaveComputer.isOnline()) {
+                    break;
+                } else if (attempts >= timesToRetryOnFailure) {
+                    taskListener.getLogger().println("Maximum retries reached. Failed to start agent client.");
+                    break;
+                }
+
+                taskListener.getLogger().println("Not up yet, waiting for " + waitTimeMs + "ms more ("
+                                                 + attempts + "/" + timesToRetryOnFailure + " retries)...");
+                Thread.sleep(waitTimeMs);
             }
         } catch (IOException e) {
             taskListener.fatalError(e.getMessage(), e);


### PR DESCRIPTION
Make "revert to snapshot" functionnality works with pipeline jobs. As soon as a pipeline exit a `node()` step, if that node is a Libvirt computer configured to "reboot after run", the virtual machine will be shutdown, and reverted to the configured snapshot if any.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

