### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/libvirt/VirtualMachineManagement/index.jelly
+++ b/src/main/resources/hudson/plugins/libvirt/VirtualMachineManagement/index.jelly
@@ -4,7 +4,7 @@
     <l:layout title="${%Hypervisor hosts}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/main/resources/hudson/plugins/libvirt/VirtualMachineManagementServer/index.jelly
+++ b/src/main/resources/hudson/plugins/libvirt/VirtualMachineManagementServer/index.jelly
@@ -11,8 +11,8 @@
         </l:header>
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="images/24x24/previous.gif" href="${rootURL}/libvirt-slave/" title="${%Hypervisor hosts}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-previous icon-md" href="${rootURL}/libvirt-slave/" title="${%Hypervisor hosts}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @bgermann 
Thanks in advance!