### PR TITLE
Fix 404s on form validation

### DIFF
--- a/src/main/java/hudson/plugins/libvirt/PluginImpl.java
+++ b/src/main/java/hudson/plugins/libvirt/PluginImpl.java
@@ -107,11 +107,11 @@ public class PluginImpl extends Plugin {
     }
 
     @POST
-    public FormValidation doCheckStartupWaitingPeriodSeconds(@QueryParameter String secsValue)
+    public FormValidation doCheckStartupWaitingPeriodSeconds(@QueryParameter String value)
             throws IOException, ServletException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         try {
-            int v = Integer.parseInt(secsValue);
+            int v = Integer.parseInt(value);
             if (v < 0) {
                 return FormValidation.error("Negative value..");
             } else if (v == 0) {
@@ -126,11 +126,11 @@ public class PluginImpl extends Plugin {
     }
 
     @POST
-    public FormValidation doCheckStartupTimesToRetryOnFailure(@QueryParameter String retriesValue)
+    public FormValidation doCheckStartupTimesToRetryOnFailure(@QueryParameter String value)
             throws IOException, ServletException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         try {
-            int v = Integer.parseInt(retriesValue);
+            int v = Integer.parseInt(value);
             if (v < 0) {
                 return FormValidation.error("Negative value.");
             } else {

--- a/src/main/resources/hudson/plugins/libvirt/VirtualMachineSlave/configure-entries.jelly
+++ b/src/main/resources/hudson/plugins/libvirt/VirtualMachineSlave/configure-entries.jelly
@@ -42,11 +42,11 @@
     </f:entry>
 
     <f:entry title="${%Startup Idle (sec)}" field="startupWaitingPeriodSeconds" help="/plugin/libvirt-slave/help-libvirt-waitingperiod.html">
-        <f:textbox checkMethod="post" default="60" checkUrl="'${rootURL}/plugin/libvirt-slave/checkStartupWaitingPeriodSeconds?secsValue='+this.value"/>
+        <f:textbox checkMethod="post" default="60" checkUrl="${rootURL}/plugin/libvirt-slave/checkStartupWaitingPeriodSeconds" checkDependsOn=""/>
     </f:entry>
 
     <f:entry title="${%Times to Retry Startup}" field="startupTimesToRetryOnFailure" help="/plugin/libvirt-slave/help-libvirt-timesToRetryOnFailure.html">
-        <f:textbox checkMethod="post" default="0" checkUrl="'${rootURL}/plugin/libvirt-slave/checkStartupTimesToRetryOnFailure?retriesValue='+this.value"/>
+        <f:textbox checkMethod="post" default="0" checkUrl="${rootURL}/plugin/libvirt-slave/checkStartupTimesToRetryOnFailure" checkDependsOn=""/>
     </f:entry>
 
     <f:entry title="${%# of executors}" field="numExecutors">

--- a/src/main/resources/hudson/plugins/libvirt/VirtualMachineSlave/configure-entries.jelly
+++ b/src/main/resources/hudson/plugins/libvirt/VirtualMachineSlave/configure-entries.jelly
@@ -50,7 +50,7 @@
     </f:entry>
 
     <f:entry title="${%# of executors}" field="numExecutors">
-        <f:textbox checkMethod="post"/>
+        <f:textbox checkMethod="post" default="1"/>
     </f:entry>
 
     <f:entry title="${%Remote FS root}" field="remoteFS">


### PR DESCRIPTION
Update the checkUrl format used in `configure-entries.jelly` to the `modern` format.

With jenkins 2.541.3, the old format seems to havestopped working. When loading the form to add or edit a computer, the fields would show a jenkins 404 page after each attempt to validate the field values.

### Testing done

With both jenkins 2.478 and 2.541:

 * Running the plugin with `mvn hpi:run`
 * Add a QEMU cloud
 * Add a libvirt-agent computer
 * Change the values of the `startupTimesToRetryOnFailure` and `startupWaitingPeriodSeconds` in the computer form to ensure that the values are validated

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
