### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <spotbugs.threshold>Low</spotbugs.threshold>

--- a/src/main/java/hudson/plugins/libvirt/Hypervisor.java
+++ b/src/main/java/hudson/plugins/libvirt/Hypervisor.java
@@ -26,6 +26,7 @@ import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.common.base.Strings;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Item;
@@ -59,7 +60,6 @@ import hudson.util.ListBoxModel;
 import java.util.Arrays;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -523,7 +523,7 @@ public class Hypervisor extends Cloud {
                 }
             }
 
-            if (StringUtils.isBlank(credentialsId)) {
+            if (Util.fixEmptyAndTrim(credentialsId) == null) {
                 return FormValidation.ok();
             }
 


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

A single `StringUtils.isBlank(credentialsId)` becomes `Util.fixEmptyAndTrim(credentialsId) == null`,
using the `hudson.Util` helper. Also enables the `ban-commons-lang-2` enforcer rule.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
